### PR TITLE
Adding cs50 docs as an example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/example/cs50docs"]
+	path = docs/example/cs50docs
+	url = git@github.com:ABD-01/cs50.readthedocs.io.git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ autodoc_default_options = {
 }
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "example/cs50docs/*"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -88,3 +88,6 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
+
+# CS50 example docs
+html_extra_path = ["example/cs50docs/build/"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ customisation
 :hidden:
 
 Week 5 Notes <example/week5>
+CS50 Docs </cs50docs/index.html#http://>
 ```
 
 ```{toctree}

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,6 @@ description = Documentation
 deps = 
     {toxinidir}[docs]
 commands = 
+    pip install -r docs/example/cs50docs/requirements.txt
+    sphinx-build docs/example/cs50docs docs/example/cs50docs/build/cs50docs -v -b dirhtml
     sphinx-build docs docs/build -v -b dirhtml


### PR DESCRIPTION
<!-- THANKS FOR YOUR CONTRIBUTION!! -->

**Describe the changes in the PR**
<!--
  Whatever level of detail is necessary to describe the changes well.
  A simple reference to associated issue(s) may suffice here
  (e.g., "Closes #113"), if the description/discussion there is
  complete enough.
-->
Added [cs50 docs](https://cs50.readthedocs.io/) as submodule in the example section

<!--
  If not indicated in the above PR description, indicate here
  which issue(s) are closed by the PR, if any; e.g.:

  Closes #112 and closes #117.

  Please use a separate 'closes' with each issue number,
  to be sure that Github links the PR correctly to each closed issue.
-->

**Does the PR change/update the following, if relevant?**
<!--
  All changes to code, even internal-only changes, should have
  a CHANGELOG entry. Documentation changes are usually only required
  if public-facing code or CLI behavior changes. Test coverage
  should be maintained at 100%, and all lints should be obeyed.

  Please specifically note if you want to use "# noqa",
  "# pragma: no cover", or similar flags/settings to disable
  any coverage/linting.
-->

- [x] Documentation
